### PR TITLE
added S3 bucket policy to accept only secure transport method for all S3 actions

### DIFF
--- a/cfn-templates/readmission-blog-cfn.yml
+++ b/cfn-templates/readmission-blog-cfn.yml
@@ -86,6 +86,13 @@ Resources:
           Condition:
             StringNotEquals:
               's3:x-amz-server-side-encryption': 'aws:kms'
+        - Principal: "*"
+          Effect: Deny
+          Action: s3:*
+          Resource: [!Sub '${MyBucket.Arn}/*', !Sub '${MyBucket.Arn}']
+          Condition:
+            Bool:
+              'aws:SecureTransport': 'false'
   MyUser:
     Type: AWS::IAM::User
     Properties:


### PR DESCRIPTION

*Issue #, if available:*
S3 bucket accepts non-secure transport, a network-based attacker eavesdropping on the network traffic can intercept or modify data in transit.

*Description of changes:*
Added new statement to S3 bucket policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
